### PR TITLE
Unidades de tiempo estandar

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -5,14 +5,14 @@ export const dateList: DateList = {
     name: "año",
     plural: "s",
     aliases: ["years", "year", "yrs", "yr", "y"],
-    unit: 31536000000,
+    unit: 31556926000,
     get: () => new Date().getFullYear(),
   },
   month: {
     name: "mes",
     plural: "es",
     aliases: ["months", "month", "mth", "mh"],
-    unit: 2592000000,
+    unit: 2629743000,
     get: () => new Date().getMonth(),
   },
   week: {


### PR DESCRIPTION
Hay una lista de unidades de tiempo (en segundos).

```md
|  Human-readable time  |      Seconds      |
|:---------------------:|:-----------------:|
| 1 hour                | 3600 seconds      |
| 1 day                 | 86400 seconds     |
| 1 week                | 604800 seconds    |
| 1 month (30.44 days)  | 2629743 seconds   |
| 1 year (365.24 days)  | 31556926 seconds  |
```

Referencia: https://www.epochconverter.com/